### PR TITLE
Making sure all IO operations use UTF-8 encoding

### DIFF
--- a/mublog.py
+++ b/mublog.py
@@ -75,7 +75,7 @@ class Helper:
         """
         command = ["pandoc", src_path, "-f", "markdown", "-t", "html"]
         try:
-            result = subprocess.run(command, check=True, capture_output=True, text=True)
+            result = subprocess.run(command, check=True, capture_output=True, text=True, encoding="utf-8")
             return result.stdout
         except subprocess.CalledProcessError:
             logger.error(f"Pandoc failed while processing {src_path}")
@@ -223,7 +223,7 @@ class Post:
         :return: True if the header is valid, False otherwise
         """
         logger.debug(f"Processing {self.src_path} ...")
-        with open(self.src_path, "r") as f:
+        with open(self.src_path, mode="r", encoding="utf-8") as f:
             md_data = f.readlines()
 
         # Validate all fields in the header
@@ -255,7 +255,7 @@ class Post:
         self.html_content = Helper.pandoc_md_to_html(self.src_path)
 
         # Load the post template and substitute the placeholders with the actual values
-        with open(os.path.join(self.paths.src_templates_dir_path, "post.html.template"), encoding="utf-8") as f:
+        with open(os.path.join(self.paths.src_templates_dir_path, "post.html.template"), mode="r", encoding="utf-8") as f:
             post_template = f.read()
 
         substitutions = {
@@ -290,7 +290,7 @@ class Page:
         self.html_content = Helper.pandoc_md_to_html(self.src_path)
 
         # Load the page template and substitute the placeholders with the actual values
-        with open(os.path.join(self.paths.src_templates_dir_path, "page.html.template"), encoding="utf-8") as f:
+        with open(os.path.join(self.paths.src_templates_dir_path, "page.html.template"), mode="r", encoding="utf-8") as f:
             page_template = f.read()
 
         substitutions = {
@@ -337,7 +337,7 @@ class TagsPage(Page):
         self.html_content = Helper.pandoc_md_to_html(self.src_path)
 
         # Load the page template and substitute the placeholders with the actual values
-        with open(os.path.join(self.paths.src_templates_dir_path, "page.html.template"), encoding="utf-8") as f:
+        with open(os.path.join(self.paths.src_templates_dir_path, "page.html.template"), mode="r", encoding="utf-8") as f:
             tags_page_template = f.read()
 
         # Get tags from posts, sorted by count and convert them to html
@@ -548,7 +548,7 @@ class Blog:
             # Validate and generate the post
             post = Post(self.config, self.paths, file_path)
             if post.validate_header():
-                with open(post.dst_path, "w", encoding="utf-8") as f:
+                with open(post.dst_path, mode="w", encoding="utf-8") as f:
                     f.write(post.generate())
                 self.processed_posts += 1
                 self.posts.append(post)
@@ -574,7 +574,7 @@ class Blog:
                 page = Page(self.config, self.paths, file_path)
 
             # Write the generated page to disk
-            with open(page.dst_path, "w", encoding="utf-8") as f:
+            with open(page.dst_path, mode="w", encoding="utf-8") as f:
                 f.write(page.generate())
             self.pages.append(page)
 
@@ -592,11 +592,11 @@ class Blog:
         # Load the JavaScript template
         tags_template_path = os.path.join(self.paths.src_templates_dir_path, "tags.js.template")
         logger.debug(f"Processing {tags_template_path} ...")
-        with open(tags_template_path, encoding="utf-8") as f:
+        with open(tags_template_path, mode="r", encoding="utf-8") as f:
             js_template = f.read()
 
         # Create a mapping of post filenames to tags and substitute the template placeholders with the actual values
-        with open(os.path.join(self.paths.dst_js_dir_path, "tags.js"), "w", encoding="utf-8") as f:
+        with open(os.path.join(self.paths.dst_js_dir_path, "tags.js"), mode="w", encoding="utf-8") as f:
             entries = [f'"{post.filename}": [{", ".join(map(repr, post.tags))}]' for post in self.posts]
             substitutions = {"tag_mapping": "\n" + ",\n".join(entries) + "\n"}
             f.write(Template(js_template).substitute(substitutions))


### PR DESCRIPTION
Since I use Windows, my default encoding is not UTF8. Because of that, pandoc would parse my MD files all wrong, so here is a fix for that.

I also made all the modes for the open method explicit, I believe it is easier to read.

Let me know your opinion.
Thanks! 