### PR TITLE
Improved table behaviour. Tables are now scrollable on overflow, if wrapping isn't sufficient

### DIFF
--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -200,15 +200,18 @@ p {
 
 table {
     margin: 0 auto;
+    max-width: 100%;
     overflow-x: auto;
+    display: block;
+    border: none;
+    border-collapse: collapse;
+    width: max-content;
 }
 
-table,
 th,
 td {
     border: 1px solid var(--color-text);
     color: var(--color-text);
-    border-collapse: collapse;
     padding: 0.5rem 0.8rem;
 }
 


### PR DESCRIPTION
Tables now don't overflow the body max-width anymore, if wrapping isn't sufficient.
The following cases are now handled properly:
- **Small table:** Even without wrapping, the table width is less than body max-width. The table is centered.
- **Medium table:** The table is wider, but by wrapping the content, the table width is equivalent to body max-width. No scrolling necessary
- **Big table:** The table has so many columns, that even width wrapping the content, an overflow of body max-width would be unavoidable. Therefore a horizontal scrollbar is introduced, to ensure the table width matches body max-width.

Closes #40.